### PR TITLE
fix: handle "busy" answer from the server on /publish and /release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 *.gem
 .tags
+.idea
 
 npm-debug.log*
 node_modules/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "client side package to work with trdl release server",
   "scripts": {
-    "dist": "./dist.sh"
+    "dist": "./dist.sh",
+    "build": "npx tsc --build"
   },
   "repository": {
     "type": "git",

--- a/src/examples/publish.ts
+++ b/src/examples/publish.ts
@@ -1,13 +1,13 @@
 import trdl = require("../trdl-client")
 
 var trdlClient = new trdl.TrdlClient({
-    vaultAddr: 'http://172.17.0.4:8200',
-    vaultToken: 'root'
+    vaultAddr: process.env.VAULT_ADDR || 'http://172.17.0.4:8200',
+    vaultToken: process.env.VAULT_TOKEN || 'root'
 });
 
 console.log("Before release")
 
-trdlClient.publish("trdl-test-project", (taskID, msg) => { console.log(`[${taskID}] ${msg}`) })
+trdlClient.publish(process.env.TRDL_RELEASE_PROJECT_NAME || "trdl-test-project", (taskID, msg) => { console.log(`[${taskID}] ${msg}`) })
     .then(() => {
         console.log("Publish done!")
     })

--- a/src/examples/release.ts
+++ b/src/examples/release.ts
@@ -1,13 +1,13 @@
 import trdl = require("../trdl-client")
 
 var trdlClient = new trdl.TrdlClient({
-    vaultAddr: 'http://172.17.0.4:8200',
-    vaultToken: 'root'
+    vaultAddr: process.env.VAULT_ADDR || 'http://172.17.0.4:8200',
+    vaultToken: process.env.VAULT_TOKEN || 'root'
 });
 
 console.log("Before release")
 
-trdlClient.release("trdl-test-project", "v0.1.20", (taskID, msg) => { console.log(`[${taskID}] ${msg}`) })
+trdlClient.release(process.env.TRDL_RELEASE_PROJECT_NAME || "trdl-test-project", process.env.TRDL_RELEASE_GIT_TAG || "v0.1.15", (taskID, msg) => { console.log(`[${taskID}] ${msg}`) })
     .then(() => {
         console.log("Release done!")
     })


### PR DESCRIPTION
Hang in a retry loop, with 5 seconds timeout, when a "busy" answer received.